### PR TITLE
hotfix: Fix importerror.

### DIFF
--- a/src/red_sysinfo/domain/platform/__init__.py
+++ b/src/red_sysinfo/domain/platform/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from . import enums, methods, schemas, utils
-from .enums import (
+from red_sysinfo.domain.enums.platform import (
     EnumLinux,
     EnumMac,
     EnumPlatform,
@@ -10,6 +9,8 @@ from .enums import (
     EnumUnix,
     EnumWin32,
 )
+
+from . import methods, schemas, utils
 from .methods import (
     get_python_base_prefix,
     get_python_copyright,


### PR DESCRIPTION
Forgot to update the domain `__init__.py` to reflect moving enums to domain.